### PR TITLE
🐛试图解决插件会对消息中的特殊符号（如[]、&）进行转义（比如&amp;或者&#xx;啥的）的问题

### DIFF
--- a/nonebot_plugin_word_bank2/__init__.py
+++ b/nonebot_plugin_word_bank2/__init__.py
@@ -63,7 +63,7 @@ async def handle_wb(event: MessageEvent, state: T_State):
     msgs: List[Message] = state["replies"]
     for msg in msgs:
         await wb_matcher.finish(
-            Message.template(msg).format(
+            Message.template(msg.extract_plain_text()).format(
                 nickname=event.sender.card or event.sender.nickname,
                 sender_id=event.sender.user_id,
             )

--- a/nonebot_plugin_word_bank2/__init__.py
+++ b/nonebot_plugin_word_bank2/__init__.py
@@ -126,7 +126,7 @@ async def wb_set(
     try:
         # 这个问题很奇怪, 有的设备上没有问题, 有的设备有问题
         # 替换掉莫名出现的 amp; 来解决
-        wb.set(index, type_, Message(key.replace("amp;", "")), value, require_to_me)
+        wb.set(index, type_, Message(key), value, require_to_me)
         await matcher.finish(message="我记住了~")
     except IncludeCQCodeError:
         await matcher.finish("正则匹配中不允许带有CQ码")
@@ -177,7 +177,7 @@ async def _(
 
     index = get_session_id(event)
     index = "0" if "全局" in flag else index
-    res = wb.delete(index, type_, Message(key.replace("amp;", "")), require_to_me)
+    res = wb.delete(index, type_, Message(key), require_to_me)
     if res:
         await matcher.finish("删除成功~")
 
@@ -291,7 +291,7 @@ async def wb_search(
                 require_to_me = True
                 break
 
-    entrys = wb.select(index, type_, Message(key.replace("amp;", "")), require_to_me)
+    entrys = wb.select(index, type_, Message(key), require_to_me)
 
     if not entrys:
         await matcher.finish("词库中未找到词条~")

--- a/nonebot_plugin_word_bank2/word_entry.py
+++ b/nonebot_plugin_word_bank2/word_entry.py
@@ -39,7 +39,7 @@ class WordEntry:
 
     def dump(self) -> Tuple[str, List[str]]:
         key = f"/atme {self.key}" if self.require_to_me else str(self.key)
-        return key, [str(v) for v in self.values]
+        return key, [str(v.extract_plain_text()) for v in self.values]
 
     def match(self, msg: Message, match_type: MatchType, to_me: bool = False) -> bool:
         msg = Message(str(msg).strip())  # 去除前后空格


### PR DESCRIPTION
首先是我的运行环境：
windows11
python 3.10
自改真寻bot，通过将文件手动放入extensive_plugins的方式加载此插件
nonebot2==2.3.0
nonebot-adapter-onebot==2.2.0
收发器：
napcatqq

可能有关：
#50 #45 #48 

我试图先在负责存储的bank.json中，解决存储的内容被转义的问题：
经分解调试，认为在`word_entry.dump()`函数中使用的`str(Message)`会导致特定符号被转义：
![image](https://github.com/kexue-z/nonebot-plugin-word-bank2/assets/74529082/cad97f40-bfea-4d06-871b-8f58f3fb3d0b)
遂换用`Message.extract_plain_text()`避免此步被转义。

我试图再解决在发送消息时，特殊符号被转义的问题：
经分解调试，认为插件触发转义的路径如下：
 *  插件在进行回复时，会调用`Message.template().format()`构造一个新消息
 *  消息会传递到`nonebot.internal.adapter.template._format()`函数中进行处理，但此时又出现了`str(Message)`，
   ![image](https://github.com/kexue-z/nonebot-plugin-word-bank2/assets/74529082/ffbde32e-e21d-4aaf-afe6-afee7d161f0f)
 * 此时调试不下去了，但发现`str(Message)`是onebotv11适配器自己重写的方法，遂进去看
   ![image](https://github.com/kexue-z/nonebot-plugin-word-bank2/assets/74529082/8f397958-5ec8-444d-aa8c-9d65162709ab)
*  escape()就很可疑了，进去破案
   ![image](https://github.com/kexue-z/nonebot-plugin-word-bank2/assets/74529082/e1b5e8dd-c900-473d-8f31-b4dc0f4c9798)
   这里面出现了转义相关代码，似乎是仅对`[`及`]`及`&`及`,`起作用。

最终结论就是v11适配器的`str(Message)`自带转义惹出来的，查阅文档后，发现`Message.template()`不一定必须`Message.template(Message)`，还可以`Message.template(字符串)`，正好能规避使用被v11重写的带有转义的`str()`，测试后发现在我的环境下能解决问题。

但此PR可能会导致使用CQ码与收发器通信的情景出现问题，我无从测试

